### PR TITLE
[헤더] header.scss 데스크탑 padding 변수 사용 및 불필요한 반응형 분기 padding 제거

### DIFF
--- a/src/layouts/header/header.scss
+++ b/src/layouts/header/header.scss
@@ -17,7 +17,7 @@ body {
   top: 0;
   left: 50%;
   transform: translateX(-50%);
-  padding: 0 rem(70);
+  padding: 0 $container-gutter;
   box-sizing: border-box;
 
   .header__logo a:focus {
@@ -122,7 +122,6 @@ body {
 // Tablet
 @media (max-width: $breakpoint-tablet) {
   .header {
-    padding: 0 rem(40);
     height: rem(56);
 
     .header__logo svg {
@@ -168,7 +167,6 @@ body {
 // Mobile
 @media (max-width: $breakpoint-mobile) {
   .header {
-    padding: 0 rem(16);
     height: rem(38);
 
     .header__logo svg {


### PR DESCRIPTION
## 설명

header.scss 파일에서 데스크탑 padding에 변수를 사용했고  불필요한 반응형 분기 padding을 제거했습니다.

## 작업 사항

- [] 새로운 로그인 API 구현
- [] 로그인 화면 UI 업데이트
- [] 기존 사용자 인증 로직 수정
- [] 새로운 기능 추가
- [] 버그 수정
- [] CSS 등 사용자 UI 디자인 변경
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [] 주석 추가 및 수정
- [] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## 관련 이슈

- 이슈 번호: #26 

## 테스트 결과

- [] 단위 테스트 추가 및 통과
- [] 통합 테스트 수행
- [x] 로컬 환경에서 수동 테스트 완료

## 참고 자료

## 체크리스트

- [x] 코드가 의도한 대로 작동하는지 확인했습니다.
- [] 새로운 기능이 문서화되었습니다.
- [] 기존 기능에 영향을 주지 않도록 충분히 테스트했습니다.
- [x] 코딩 컨벤션을 준수했습니다.

## 스크린샷

## 추가 정보
